### PR TITLE
fix: retry skipped playlist items on every official API full scan

### DIFF
--- a/backend/src/main/java/top/asimov/pigeon/service/PlaylistService.java
+++ b/backend/src/main/java/top/asimov/pigeon/service/PlaylistService.java
@@ -448,6 +448,7 @@ public class PlaylistService extends AbstractFeedService<Playlist> {
 
       List<PlaylistItem> remoteItems = youtubePlaylistHelper.fetchAllPlaylistItemsOfficial(playlist.getId());
       OfficialItemDiffResult diffResult = applyOfficialItemDiff(playlist, remoteItems, now);
+      youtubePlaylistItemMapper.resetSkippedMaterialization(playlist.getId(), now);
       int materializedCount = materializeOfficialPlaylistItems(playlist, now);
       DerivePlaylistEpisodeResult deriveResult = derivePlaylistEpisodesFromOfficialItems(playlist);
       int dispatchedCount = 0;


### PR DESCRIPTION
Fixes #153

## Problem

Since the YouTube playlist sync was migrated to the official API,
episodes added to a playlist as YouTube Premieres or active live streams
are silently skipped and never recovered.

When the first sync sees a Premiere in `upcoming`/`live` state,
`shouldSkipLiveContent()` returns true and the item is marked `SKIPPED`.
Once the Premiere ends and the video becomes a regular VOD, subsequent
syncs ignore it — `selectPendingMaterialization` only queries
`IN ('PENDING', 'FAILED')`, so `SKIPPED` items are never retried.

The only existing recovery path is `resetSkippedMaterialization`, called
in `updatePlaylistConfig` — meaning users had to edit their playlist
settings to accidentally trigger a fix they didn't know was needed.

## Root cause

`syncYoutubePlaylistWithOfficialApi` never called
`resetSkippedMaterialization` before materializing items.

## Fix

Call `resetSkippedMaterialization` before each full scan so that skipped
items are re-evaluated on every sync cycle. The extra API cost is at most
one batched `videos.list` call (1 quota unit per 50 items) per cycle,
only while skipped items exist.

## How to reproduce

1. Add a YouTube playlist containing a scheduled Premiere.
2. Wait for the auto-sync to run while the Premiere is upcoming/live.
3. Wait for the Premiere to end.
4. Trigger a manual refresh → the episode never appears.
   Log shows: `materialized=0, derived=N` where N excludes the Premiere.
