### PR TITLE
fix: allow hyphens in subtitle language codes

### DIFF
--- a/backend/src/main/java/top/asimov/pigeon/service/MediaService.java
+++ b/backend/src/main/java/top/asimov/pigeon/service/MediaService.java
@@ -502,7 +502,7 @@ public class MediaService {
     String mediaDir = mediaFile.getParent();
     String mediaBaseName = mediaFile.getName().replaceFirst("\\.[^.]+$", "");
     File dir = new File(mediaDir);
-    Pattern pattern = Pattern.compile(Pattern.quote(mediaBaseName) + "\\.(\\w+)\\.(vtt|srt)$");
+    Pattern pattern = Pattern.compile(Pattern.quote(mediaBaseName) + "\\.([\\w-]+)\\.(vtt|srt)$");
 
     File[] files = dir.listFiles();
     if (files != null) {


### PR DESCRIPTION
Fixes an issue where language codes with hyphens (like `zh-Hans`) were not correctly detected because the regex used `\w+` instead of `[\w-]+`.