### PR TITLE
fix: restore the broken star history chart

### DIFF
--- a/README.md
+++ b/README.md
@@ -214,7 +214,7 @@ npm run dev
 
 ## Star History
 
-[![Star History Chart](https://api.star-history.com/svg?repos=aizhimou/pigeon-pod&type=Timeline)](https://www.star-history.com/#aizhimou/pigeon-pod&Timeline)
+[![Star History Chart](https://star-history.dera.page/svg?repos=aizhimou/pigeon-pod&type=Timeline)](https://star-history.dera.page/#aizhimou/pigeon-pod&Timeline)
 ---
 
 <div align="center">


### PR DESCRIPTION
The star history chart in the README stopped working because of GitHub stargazer API restrictions. This change points it to star-history.dera.page, an alternative that requires no API token, so the chart renders again.